### PR TITLE
Update cmb-field-gallery.php

### DIFF
--- a/cmb-field-gallery.php
+++ b/cmb-field-gallery.php
@@ -24,7 +24,7 @@ function pw_gallery_field( $field, $meta ) {
 
 	echo '<div class="pw-gallery">';
 	echo '	<input type="hidden" id="' . $field->args( 'id' ) . '" name="' . $field->args( 'id' ) . '" value="' . $meta . '" />';
-	echo '	<input type="button" class="button" value="' . ( ! empty( $field->args( 'button' ) ) ? $field->args( 'button' ) : 'Manage gallery' ) . '" style="margin-left: 0;" />';
+	echo '	<input type="button" class="button" value="' . ( $field->args( 'button' ) ? $field->args( 'button' ) : 'Manage gallery' ) . '" style="margin-left: 0;" />';
 	echo '</div>';
 
 	$desc = $field->args( 'desc' );


### PR DESCRIPTION
Remove empty() on $field->args( 'button' ) to avoid "Can't use function return value in write context in..." errors below PHP 5.5
